### PR TITLE
Adds support for n d input image in training plot viewer

### DIFF
--- a/code/+p2p/+vis/TrainingPlot.m
+++ b/code/+p2p/+vis/TrainingPlot.m
@@ -12,7 +12,6 @@ classdef TrainingPlot < handle
         InputsIm
         OutputsIm
         ExampleInputs
-        PrepForPlot = @(x) (gather(extractdata(x)) + 1)/2
         Lines = matlab.graphics.animation.AnimatedLine.empty
         StartTime
     end
@@ -45,14 +44,13 @@ classdef TrainingPlot < handle
         
         function update(obj, epoch, iteration,  ...
                     gLoss, lossL1, ganLoss, dLoss, generator)
-            % TODO update loss plots
             obj.updateImages(generator)
             obj.updateLines(epoch, iteration, gLoss, lossL1, ganLoss, dLoss);
             drawnow();
         end
         
         function initImages(obj)
-            displayIm = obj.PrepForPlot(obj.ExampleInputs);
+            displayIm = obj.prepForPlot(obj.ExampleInputs);
             montageIm = imtile(displayIm);
             obj.InputsIm = imshow(montageIm, "Parent", obj.InputsAx);
             
@@ -100,6 +98,19 @@ classdef TrainingPlot < handle
             addpoints(obj.Lines(2), iteration, double(lossL1));
             addpoints(obj.Lines(3), iteration, double(ganLoss));
             addpoints(obj.Lines(4), iteration, double(dLoss));
+        end
+        
+    end
+    
+    methods (Static)
+        function imOut = prepForPlot(im)
+            nChannels = size(im, 3);
+            imOut = (gather(extractdata(im)) + 1)/2;
+            
+            % only take the first channel for n != 3
+            if nChannels ~= 3
+                imOut = imOut(:,:,1);
+            end
         end
     end
 end

--- a/code/+p2p/+vis/TrainingPlot.m
+++ b/code/+p2p/+vis/TrainingPlot.m
@@ -109,7 +109,7 @@ classdef TrainingPlot < handle
             
             % only take the first channel for n != 3
             if nChannels ~= 3
-                imOut = imOut(:,:,1);
+                imOut = imOut(:,:,1,:);
             end
         end
     end

--- a/tests/+tests/TrainingPlotTest.m
+++ b/tests/+tests/TrainingPlotTest.m
@@ -1,0 +1,26 @@
+classdef TrainingPlotTest < matlab.unittest.TestCase
+% Test of training plots
+
+% Copyright 2020 The MathWorks, Inc.
+    properties (TestParameter)
+        inChannels = {1, 2, 3, 4}
+        outChannels = {1, 1, 3, 1}
+    end
+    
+    methods (Test, ParameterCombination='sequential')
+        function testPrepForPlot(test, inChannels, outChannels)
+            h = 100;
+            w = 200;
+            c = inChannels;
+            im = dlarray(zeros(h, w, c, "single"), "SSCB");
+            
+            imOut = p2p.vis.TrainingPlot.prepForPlot(im);
+            
+            test.assertEqual(size(imOut, [1, 2]), [h, w], ...
+                "Height and width should be preserved");
+            test.assertEqual(size(imOut, 3), outChannels, ...
+                "Channels not as expected");
+        end
+        
+    end
+end


### PR DESCRIPTION
Expected behaviour is to interpret channels as RGB for 3 channel input images For any other number of channels the first channel is displayed as a grayscale.